### PR TITLE
eliminate invalid fmt.Errorf call

### DIFF
--- a/client/sse.go
+++ b/client/sse.go
@@ -424,9 +424,9 @@ func (t *SSETransport) SendWithContext(ctx context.Context, message []byte) ([]b
 	// Check response status
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		errMsg := fmt.Sprintf("HTTP request failed with status: %d, body: %s", resp.StatusCode, string(body))
-		t.logger.Debug(errMsg)
-		return nil, fmt.Errorf(errMsg)
+		errMsg := fmt.Errorf("HTTP request failed with status: %d, body: %s", resp.StatusCode, string(body))
+		t.logger.Debug(errMsg.Error())
+		return nil, errMsg
 	}
 
 	// Read the response body

--- a/transport/sse/sse.go
+++ b/transport/sse/sse.go
@@ -485,11 +485,11 @@ func (t *Transport) connectToSSE() error {
 
 	req, err := http.NewRequest("GET", eventsURL, nil)
 	if err != nil {
-		errMsg := fmt.Sprintf("Failed to create SSE request: %v", err)
+		errMsg := fmt.Errorf("Failed to create SSE request: %w", err)
 		if debugHandler := t.GetDebugHandler(); debugHandler != nil {
-			debugHandler(errMsg)
+			debugHandler(errMsg.Error())
 		}
-		return fmt.Errorf(errMsg)
+		return errMsg
 	}
 
 	// Set headers for SSE request


### PR DESCRIPTION
NOTE: `cd client && go test .` failed with "non-constant format string in call to fmt.Errorf", but `cd client && go build .` did not fail. I believe this comes from `go vet` which implicitly runs when `go test` is invoked

Issue incidentally found when evaluating potential fix for #5 